### PR TITLE
Removed 'www'

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   },
   "content_scripts": [
     {
-      "matches": [ "*://www.ivelt.com/*" ],
+      "matches": [ "*://*.ivelt.com/*" ],
       "js": [ "contentScript.js" ]
     }
   ],


### PR DESCRIPTION
Remove 'www' so it works even when navigating to ivelt.com (https://ivelt.com) without www (https://www.ivelt.com)