### PR TITLE
Fix cors for chrome - Tested

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -2,7 +2,7 @@ const notificationUrl =
   "http://www.ivelt.com/forum/ucp.php?i=ucp_notifications";
 
 let checkNewNotification = function () {
-  fetch(notificationUrl)
+  fetch(notificationUrl, { mode: "no-cors" })
     .then((response) => response.text())
     .then((data) => {
       let matches =

--- a/src/background.js
+++ b/src/background.js
@@ -1,34 +1,33 @@
-const notificationUrl = "http://www.ivelt.com/forum/ucp.php?i=ucp_notifications";
+const notificationUrl =
+  "http://www.ivelt.com/forum/ucp.php?i=ucp_notifications";
 
-let checkNewNotification = function() {
-    fetch(notificationUrl)
-    .then(response => response.text())
-    .then(data => {
-        let matches = (data.match(/id="notification_list_button"\D*(\d{1,4})/) || []);
-        let newCount = matches.length == 2 ? matches[1] : '0'
-        if (newCount !== '0') {
-            chrome.browserAction.setBadgeText({text: newCount});
-        }
-        else{
-            chrome.browserAction.setBadgeText({text: ''});
-        }
+let checkNewNotification = function () {
+  fetch(notificationUrl)
+    .then((response) => response.text())
+    .then((data) => {
+      let matches =
+        data.match(/id="notification_list_button"\D*(\d{1,4})/) || [];
+      let newCount = matches.length == 2 ? matches[1] : "0";
+      if (newCount !== "0") {
+        chrome.browserAction.setBadgeText({ text: newCount });
+      } else {
+        chrome.browserAction.setBadgeText({ text: "" });
+      }
     });
-}
+};
 
-chrome.alarms.onAlarm.addListener(a => {
-    checkNewNotification();
+chrome.alarms.onAlarm.addListener((a) => {
+  checkNewNotification();
 });
 
 chrome.runtime.onInstalled.addListener(() => {
-    chrome.alarms.get('alarm', a => {
-        if (!a) {
-            chrome.alarms.create('alarm', {periodInMinutes: 1});
-        }
-    });
+  chrome.alarms.get("alarm", (a) => {
+    if (!a) {
+      chrome.alarms.create("alarm", { periodInMinutes: 1 });
+    }
+  });
 });
 
-chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
-            chrome.browserAction.setBadgeText({text:request.text});
-    }
-);
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  chrome.browserAction.setBadgeText({ text: request.text });
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,41 +1,33 @@
 {
-    "update_url": "https://clients2.google.com/service/update2/crx",
-    "manifest_version": 2,
-    "name": "ivelt keyboard shortcuts",
-    "description": "enabe to go forward or backward in ivelt forums by pressing the right and left buttons, and other accessibility features for ivelt",
-    "version": "1.6",
-    "icons": {
-        "48": "images/ivelt-logo-48x48.png",
-        "128": "images/ivelt-logo-128x128.png"
-    },
-    "content_scripts": [
-        {
-            "matches": [
-                "*://*.ivelt.com/*",
-                "*://*.yiddishworld.com/*",
-                "*://*.198.153.76.147/*"
-            ],
-            "js": [
-                "contentScript.js",
-                "refreshNotificationCount.js"
-            ]
-        }
-    ],
-    "background": {
-        "service_worker": "background.js"
-    },
-    "browser_action": {
-
-    },
-    "permissions": [ "alarms" ],
-    "web_accessible_resources": [
-        "keyboardShortcuts.js",
-        "removeNestedQuotes.js",
-        "addQuoteLastOnlyButton.js",
-        "newResponseNotification.js"
-    ],
-    "host_permissions": [
-      "http://*.ivelt.com/",
-      "https://*.ivelt.com/"
-    ]
+  "update_url": "https://clients2.google.com/service/update2/crx",
+  "manifest_version": 2,
+  "name": "ivelt keyboard shortcuts",
+  "description": "enabe to go forward or backward in ivelt forums by pressing the right and left buttons, and other accessibility features for ivelt",
+  "version": "1.6",
+  "icons": {
+    "48": "images/ivelt-logo-48x48.png",
+    "128": "images/ivelt-logo-128x128.png"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.ivelt.com/*",
+        "*://*.yiddishworld.com/*",
+        "*://*.198.153.76.147/*"
+      ],
+      "js": ["contentScript.js", "refreshNotificationCount.js"]
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "browser_action": {},
+  "permissions": ["alarms"],
+  "web_accessible_resources": [
+    "keyboardShortcuts.js",
+    "removeNestedQuotes.js",
+    "addQuoteLastOnlyButton.js",
+    "newResponseNotification.js"
+  ],
+  "host_permissions": ["http://*.ivelt.com/", "https://*.ivelt.com/"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,5 @@
     "removeNestedQuotes.js",
     "addQuoteLastOnlyButton.js",
     "newResponseNotification.js"
-  ],
-  "host_permissions": ["http://*.ivelt.com/", "https://*.ivelt.com/"]
+  ]
 }


### PR DESCRIPTION
The previous fix did not resolve the issue.
The added tags in the manifest is not supported in v2 used in this manifest.
This PR fixes the issue by instructing Fetch to ignore cors by passing the no-cors mode.