### PR TITLE
Remove unnecessary last quote buttons

### DIFF
--- a/extension/js/addQuoteLastOnlyButton.js
+++ b/extension/js/addQuoteLastOnlyButton.js
@@ -1,16 +1,25 @@
 function addBtn(){
     let btns = document.querySelectorAll('.post-buttons');
     btns.forEach(btn => {
-    let li = document.createElement('li');
-    let a = document.createElement('a');
-    let href = btn.querySelector('a.button.icon-button.quote-icon').getAttribute('href');
-    a.setAttribute('href', href + '&last=true');
-    a.setAttribute('style', "height:18px;width:12px;margin:0;padding:0 5px;color:black;text-align:center;user-select:none;");
-    a.setAttribute('class', 'button');
-    a.setAttribute('title', 'ציטיר בלויז די לעצטע תגובה');
-    li.appendChild(a);
-    btn.appendChild(li);
-    a.innerText = '-'
+        let contentElement = btn.parentElement.getElementsByClassName("content").item(0)
+        let blockquotes = contentElement.getElementsByTagName("blockquote")
+        console.log(contentElement.innerText) 
+        if (contentElement.innerHTML.includes("blockquote")){
+            
+            let li = document.createElement('li');
+            let a = document.createElement('a');
+            let href = btn.querySelector('a.button.icon-button.quote-icon').getAttribute('href');
+            a.setAttribute('href', href + '&last=true');
+            a.setAttribute('style', "height:18px;width:12px;margin:0;padding:0 5px;color:black;text-align:center;user-select:none;");
+            a.setAttribute('class', 'button');
+            a.setAttribute('title', 'ציטיר בלויז די לעצטע תגובה');
+            li.appendChild(a);
+            btn.appendChild(li);
+            a.innerText = '-'
+        }else{
+            console.log("No blockquote " + blockquotes.length)
+        }
+
     });
     }
 

--- a/extension/js/addQuoteLastOnlyButton.js
+++ b/extension/js/addQuoteLastOnlyButton.js
@@ -2,8 +2,6 @@ function addBtn(){
     let btns = document.querySelectorAll('.post-buttons');
     btns.forEach(btn => {
         let contentElement = btn.parentElement.getElementsByClassName("content").item(0)
-        let blockquotes = contentElement.getElementsByTagName("blockquote")
-        console.log(contentElement.innerText) 
         if (contentElement.innerHTML.includes("blockquote")){
             
             let li = document.createElement('li');

--- a/extension/js/addQuoteLastOnlyButton.js
+++ b/extension/js/addQuoteLastOnlyButton.js
@@ -1,16 +1,20 @@
 function addBtn(){
     let btns = document.querySelectorAll('.post-buttons');
+    let isPosting = (window.location.href.includes("posting.php"))
     btns.forEach(btn => {
         let contentElement = btn.parentElement.getElementsByClassName("content").item(0)
         if (contentElement.innerHTML.includes("blockquote")){
-            
             let li = document.createElement('li');
             let a = document.createElement('a');
             let href = btn.querySelector('a.button.icon-button.quote-icon').getAttribute('href');
+            let onclick = btn.querySelector('a.button.icon-button.quote-icon').getAttribute('onclick');
             a.setAttribute('href', href + '&last=true');
             a.setAttribute('style', "height:18px;width:12px;margin:0;padding:0 5px;color:black;text-align:center;user-select:none;");
             a.setAttribute('class', 'button');
             a.setAttribute('title', 'ציטיר בלויז די לעצטע תגובה');
+            if (isPosting){
+                a.setAttribute("onclick", "last"+onclick)
+            }
             li.appendChild(a);
             btn.appendChild(li);
             a.innerText = '-'

--- a/extension/js/addQuoteLastOnlyButton.js
+++ b/extension/js/addQuoteLastOnlyButton.js
@@ -16,10 +16,7 @@ function addBtn(){
             li.appendChild(a);
             btn.appendChild(li);
             a.innerText = '-'
-        }else{
-            console.log("No blockquote " + blockquotes.length)
         }
-
     });
     }
 

--- a/extension/js/removeNestedQuotes.js
+++ b/extension/js/removeNestedQuotes.js
@@ -34,60 +34,29 @@ if (onlyLastQuote) {
 	}
 }
 
-function lastaddquote(post_id, username, l_wrote) {
-	var message_name = 'message_' + post_id;
-	var theSelection = '';
-	var divarea = false;
-	var i;
+function lastaddquote(post_id, username) {
+	let messageName= 'message_' + post_id;
+	let theSelection = '';
+	let divArea = false;
 
-	if (l_wrote === undefined) {
-		// Backwards compatibility
-		l_wrote = 'wrote';
+	divArea = document.getElementById(messageName);
+
+	if (divArea.innerHTML) {
+		theSelection = divArea.innerHTML.replace(/<br>/ig, '\n');
+		theSelection = theSelection.replace(/<br\/>/ig, '\n');
+		theSelection = theSelection.replace(/&lt\;/ig, '<');
+		theSelection = theSelection.replace(/&gt\;/ig, '>');
+		theSelection = theSelection.replace(/&amp\;/ig, '&');
+		theSelection = theSelection.replace(/&nbsp\;/ig, ' ');
+	}  else if (divArea.textContent) {
+		theSelection = divArea.textContent;
+	} else if (divArea.firstChild.nodeValue) {
+		theSelection = divArea.firstChild.nodeValue;
 	}
 
-	if (document.all) {
-		divarea = document.all[message_name];
-	} else {
-		divarea = document.getElementById(message_name);
-	}
-
-	// Get text selection - not only the post content :(
-	// IE9 must use the document.selection method but has the *.getSelection so we just force no IE
-	if (window.getSelection && !is_ie && !window.opera) {
-		theSelection = window.getSelection().toString();
-	} else if (document.getSelection && !is_ie) {
-		theSelection = document.getSelection();
-	} else if (document.selection) {
-		theSelection = document.selection.createRange().text;
-	}
-
-	if (theSelection === '' || typeof theSelection === 'undefined' || theSelection === null) {
-		if (divarea.innerHTML) {
-			theSelection = divarea.innerHTML.replace(/<br>/ig, '\n');
-			theSelection = theSelection.replace(/<br\/>/ig, '\n');
-			theSelection = theSelection.replace(/&lt\;/ig, '<');
-			theSelection = theSelection.replace(/&gt\;/ig, '>');
-			theSelection = theSelection.replace(/&amp\;/ig, '&');
-			theSelection = theSelection.replace(/&nbsp\;/ig, ' ');
-		} else if (document.all) {
-			theSelection = divarea.innerText;
-		} else if (divarea.textContent) {
-			theSelection = divarea.textContent;
-		} else if (divarea.firstChild.nodeValue) {
-			theSelection = divarea.firstChild.nodeValue;
-		}
-	}
 	if (theSelection) {
-		if (bbcodeEnabled) {
-			let text = '[quote="' + username + '"]' + theSelection + '[/quote]'
-			insert_text(removeNestedQuotes(text));
-		} else {
-			insert_text(username + ' ' + l_wrote + ':' + '\n');
-			var lines = split_lines(theSelection);
-			for (i = 0; i < lines.length; i++) {
-				insert_text('> ' + lines[i] + '\n');
-			}
-		}
+		let text = '[quote="' + username + '"]' + theSelection + '[/quote]'
+		insert_text(removeNestedQuotes(text));
 	}
 
 	return;

--- a/extension/js/removeNestedQuotes.js
+++ b/extension/js/removeNestedQuotes.js
@@ -33,3 +33,62 @@ if (onlyLastQuote) {
 		messageArea.innerHTML = text;
 	}
 }
+
+function lastaddquote(post_id, username, l_wrote) {
+	var message_name = 'message_' + post_id;
+	var theSelection = '';
+	var divarea = false;
+	var i;
+
+	if (l_wrote === undefined) {
+		// Backwards compatibility
+		l_wrote = 'wrote';
+	}
+
+	if (document.all) {
+		divarea = document.all[message_name];
+	} else {
+		divarea = document.getElementById(message_name);
+	}
+
+	// Get text selection - not only the post content :(
+	// IE9 must use the document.selection method but has the *.getSelection so we just force no IE
+	if (window.getSelection && !is_ie && !window.opera) {
+		theSelection = window.getSelection().toString();
+	} else if (document.getSelection && !is_ie) {
+		theSelection = document.getSelection();
+	} else if (document.selection) {
+		theSelection = document.selection.createRange().text;
+	}
+
+	if (theSelection === '' || typeof theSelection === 'undefined' || theSelection === null) {
+		if (divarea.innerHTML) {
+			theSelection = divarea.innerHTML.replace(/<br>/ig, '\n');
+			theSelection = theSelection.replace(/<br\/>/ig, '\n');
+			theSelection = theSelection.replace(/&lt\;/ig, '<');
+			theSelection = theSelection.replace(/&gt\;/ig, '>');
+			theSelection = theSelection.replace(/&amp\;/ig, '&');
+			theSelection = theSelection.replace(/&nbsp\;/ig, ' ');
+		} else if (document.all) {
+			theSelection = divarea.innerText;
+		} else if (divarea.textContent) {
+			theSelection = divarea.textContent;
+		} else if (divarea.firstChild.nodeValue) {
+			theSelection = divarea.firstChild.nodeValue;
+		}
+	}
+	if (theSelection) {
+		if (bbcodeEnabled) {
+			let text = '[quote="' + username + '"]' + theSelection + '[/quote]'
+			insert_text(removeNestedQuotes(text));
+		} else {
+			insert_text(username + ' ' + l_wrote + ':' + '\n');
+			var lines = split_lines(theSelection);
+			for (i = 0; i < lines.length; i++) {
+				insert_text('> ' + lines[i] + '\n');
+			}
+		}
+	}
+
+	return;
+}


### PR DESCRIPTION
Some posts don't have quotes, so it is not necessary to have a button to quote only last. This fix checks if the post has a quote, and only then does it add the extra button.