### PR TITLE
Browser notifications

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,18 +1,26 @@
-const notificationUrl =
-  "http://www.ivelt.com/forum/ucp.php?i=ucp_notifications";
+const notificationUrl = "http://www.ivelt.com/forum/ucp.php?i=ucp_notifications";
 
 let checkNewNotification = function () {
-  fetch(notificationUrl)
-    .then((response) => response.text())
-    .then((data) => {
+    fetch(notificationUrl)
+      .then((response) => response.text())
+      .then((data) => {
+
       let matches =
         data.match(/id="notification_list_button"\D*(\d{1,4})/) || [];
       let newCount = matches.length == 2 ? matches[1] : "0";
+
       if (newCount !== "0") {
         chrome.browserAction.setBadgeText({ text: newCount });
       } else {
         chrome.browserAction.setBadgeText({ text: "" });
       }
+
+      // send html to a hidden ivelt window for parsing
+      chrome.storage.sync.get(['getBrowserNotifications'], function(items){
+        if(items.getBrowserNotifications){
+          parseAndSendNotifications(data);
+        }
+      });
     });
 };
 
@@ -29,7 +37,14 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  chrome.browserAction.setBadgeText({ text: request.text });
+  if(request.type === 'badgeText'){
+    chrome.browserAction.setBadgeText({ text: request.text });
+  }
+
+  // global method to send a notification
+  if(request.type === 'browserNotification'){
+    queueNotification(request);
+  }
 });
 
 chrome.webRequest.onBeforeRequest.addListener(
@@ -37,3 +52,5 @@ chrome.webRequest.onBeforeRequest.addListener(
   {urls: ['*://www.ןהקךא.com/*']},
   ["blocking"]
 );
+
+importScripts('./background.notifications.js')

--- a/extension/background.js
+++ b/extension/background.js
@@ -15,7 +15,7 @@ let checkNewNotification = function () {
         chrome.browserAction.setBadgeText({ text: "" });
       }
 
-      // send html to a hidden ivelt window for parsing
+      // triggere browser notifications
       chrome.storage.sync.get(['getBrowserNotifications'], function(items){
         if(items.getBrowserNotifications){
           parseAndSendNotifications(data);

--- a/extension/background.notifications.js
+++ b/extension/background.notifications.js
@@ -68,7 +68,7 @@ function parseAndSendNotifications(data){
     // save sent items in storage
     // TODO: prune old ids to avoid storage quota errors
     chrome.storage.sync.set({
-      'notificationsSent': items.notificationsSent + ',' + saveNewIds
+      'notificationsSent': (items.notificationsSent ? items.notificationsSent + ',' : '') + saveNewIds
     }, () => {
       // dont send the initial batch
       if(storeOnly){

--- a/extension/background.notifications.js
+++ b/extension/background.notifications.js
@@ -1,0 +1,144 @@
+const origin = 'https://www.ivelt.com/';
+let initialNotificationBatch = true;
+
+var queue = [];
+var queueTimer = null;
+var linkMap = {};
+
+chrome.notifications.onClicked.addListener(function(notifId) {
+    if(linkMap[notifId]){
+      // got to link
+      chrome.tabs.create({url: linkMap[notifId]}, tab => {
+        // focus window
+        chrome.windows.update(tab.windowId, {focused: true});
+        // remove notification from feed
+        chrome.notifications.clear(notifId, wasCleared => {
+          if(wasCleared)
+            delete linkMap[notifId];
+        });
+      });
+    }
+});
+
+function parseAndSendNotifications(data){
+  var unreadElements = getTagContent(data, 'li', 'row bg3');
+  var storeOnly = false;
+
+  if(initialNotificationBatch){
+    initialNotificationBatch = false;
+    storeOnly = true;
+  }
+
+  if(!unreadElements.length){
+    return;
+  }
+
+  var unread = unreadElements.map(item => {
+
+    var notificationParts = getTagContent(item, 'p', 'notifications_title', true)[0].split(':');
+    var time = getTagContent(item, 'p', 'notifications_time', true)[0];
+    var link = htmlToText(getAttrValue(item, 'a', 'href')); // to text for htmlized "&"
+
+    return {
+      title: notificationParts.shift(),
+      message: notificationParts.join(':'),
+      link: link.replace('./', origin + 'forum/'),
+      subMessage: time,
+      id: getAttrValue(item, 'input', 'value')
+    }
+  });
+
+  chrome.storage.sync.get(['notificationsSent'], items => {
+    
+    // filter sent items
+    if(items.notificationsSent){
+      unread = unread.filter(u => {
+        return !items.notificationsSent.includes(u.id)
+      });
+    }
+
+    if(!unread.length)
+      return;
+
+    var saveNewIds = unread.map(u => {
+      linkMap[u.id] = u.link;
+      return u.id;
+    }).join(',');
+
+    // save sent items in storage
+    // TODO: prune old ids to avoid storage quota errors
+    chrome.storage.sync.set({
+      'notificationsSent': items.notificationsSent + ',' + saveNewIds
+    }, () => {
+      // dont send the initial batch
+      if(storeOnly){
+        return;
+      }
+
+      unread.forEach(u => queueNotification(u));
+    });
+  });
+}
+
+// send one browser notification at a time, every 10 seconds
+function queueNotification(notification){
+
+  queue.push(notification);
+
+  if(!queueTimer){
+    queueTimer = setInterval(function(){
+      if(queue.length)
+        sendBrowserNotification(queue.shift());
+      else{
+        clearInterval(queueTimer);
+        queueTimer = null;
+      }
+    }, 10000);
+  }
+}
+
+function sendBrowserNotification(item){
+  chrome.notifications.create(item.id, {
+    type: 'basic',
+    iconUrl: origin + 'fav/apple-icon-60x60.png',
+    title: item.title,
+    message: item.message,
+    contextMessage: item.subMessage,
+    priority: 2
+  });
+}
+
+function getTagContent(string, tag, className, textOnly){
+
+  const startEl = `<${tag} class="${className}">`;
+  const endEl = `</${tag}>`;
+
+  var splitted = string.split(startEl);
+
+  // remove value before the tag
+  splitted.shift();
+
+  splitted = splitted.map(s => {
+
+    var content = s.split(endEl)[0];
+
+    if(textOnly)
+      return htmlToText(content);
+
+    return startEl + content + endEl;
+  });
+
+  return splitted;
+}
+
+function getAttrValue(string, tag, attr){
+  return string.match(new RegExp(`<${tag}.*${attr}="([^"]+)"`))[1];
+}
+
+function htmlToText(string){
+  return string.replace(/<[^>]*>/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .replace('&amp;', '&')
+    .replace(/&[a-z]+;/g, '')
+    .trim();
+}

--- a/extension/js/refreshNotificationCount.js
+++ b/extension/js/refreshNotificationCount.js
@@ -1,10 +1,10 @@
 let checkNewNotification = function() {
-    let newCount = (notificationNode.innerHTML.match(/\d+/) || ['0'])[0]
+    let newCount = (notificationNode.innerHTML.match(/\d+/) || ['0'])[0];
     if (newCount !== '0') {
-        chrome.runtime.sendMessage({text: newCount});
+        chrome.runtime.sendMessage({text: newCount, type: 'badgeText'});
     }
     else{
-        chrome.runtime.sendMessage({text: ''});
+        chrome.runtime.sendMessage({text: '', type: 'badgeText'});
     }
 }
 

--- a/extension/js/settings.js
+++ b/extension/js/settings.js
@@ -8,12 +8,7 @@ function startListeners(){
 
 	// get browser notification checkbox
 	document.getElementById('getBrowserNotifications').addEventListener('change', (e) => {
-		const getBrowserNotifications = !!e.currentTarget.checked;
-		
-		commitNewSetting({getBrowserNotifications: getBrowserNotifications});
-
-		if(getBrowserNotifications)
-			chrome.runtime.sendMessage({title: 'אייוועלט נאטיפיקאציע', message: 'דאס איז א סעמפל אייוועלט נאטיפיקאציע', type: 'browserNotification'});
+		commitNewSetting({getBrowserNotifications: !!e.currentTarget.checked});
 	});
 }
 
@@ -23,27 +18,27 @@ function commitNewSetting(nameValue){
 	chrome.storage.sync.set(nameValue, function() {
 		// Let user know options were saved.
 		const fadeTarget = document.getElementById('notify');
-	    fadeTarget.classList.add('fade');
-	    setTimeout(function() {
-	        fadeTarget.classList.remove('fade');
-	    }, 3650);
+		fadeTarget.classList.add('fade');
+		setTimeout(function() {
+			fadeTarget.classList.remove('fade');
+		}, 3650);
 	});
 }
 
 // Restores settings options using the preferences
 // stored in chrome.storage.
 function initSettings() {
-  
-  // Get preferences or set defaults
-  chrome.storage.sync.get({
-	hideUserName: false,
-	getBrowserNotifications: false
-  }, function(items) {
-	document.getElementById('hideUserName').checked = items.hideUserName;
-	document.getElementById('getBrowserNotifications').checked = items.getBrowserNotifications;
 
-	startListeners();
-  });
+	// Get preferences or set defaults
+	chrome.storage.sync.get({
+		hideUserName: false,
+		getBrowserNotifications: false
+	}, function(items) {
+		document.getElementById('hideUserName').checked = items.hideUserName;
+		document.getElementById('getBrowserNotifications').checked = items.getBrowserNotifications;
+
+		startListeners();
+	});
 }
 
 document.addEventListener('DOMContentLoaded', initSettings);

--- a/extension/js/settings.js
+++ b/extension/js/settings.js
@@ -1,37 +1,49 @@
-// Saves options to chrome.storage
-function showHideUserName(e) {
-  var hideUserName = !!e.currentTarget.checked;
-  chrome.storage.sync.set({
-    hideUserName: hideUserName
-  }, function() {
-    // Update status to let user know options were saved.
-    // Will not be useful with multiple settings, autosave with no user messages is the corect way.
-    const fadeTarget = document.getElementById('notify');
-    fadeTarget.classList.add('fade');
-    setTimeout(function() {
-        fadeTarget.classList.remove('fade');
-    }, 3650);
-  });
-}
-
+// Listen to settings changes
 function startListeners(){
 
-  // hide user name checkbox
-  document.getElementById('hideUserName').addEventListener('change', showHideUserName);
+	// hide user name checkbox
+	document.getElementById('hideUserName').addEventListener('change', (e) => {
+		commitNewSetting({hideUserName: !!e.currentTarget.checked});
+	});
+
+	// get browser notification checkbox
+	document.getElementById('getBrowserNotifications').addEventListener('change', (e) => {
+		const getBrowserNotifications = !!e.currentTarget.checked;
+		
+		commitNewSetting({getBrowserNotifications: getBrowserNotifications});
+
+		if(getBrowserNotifications)
+			chrome.runtime.sendMessage({title: 'אייוועלט נאטיפיקאציע', message: 'דאס איז א סעמפל אייוועלט נאטיפיקאציע', type: 'browserNotification'});
+	});
+}
+
+// Saves settings to chrome.storage
+function commitNewSetting(nameValue){
+
+	chrome.storage.sync.set(nameValue, function() {
+		// Let user know options were saved.
+		const fadeTarget = document.getElementById('notify');
+	    fadeTarget.classList.add('fade');
+	    setTimeout(function() {
+	        fadeTarget.classList.remove('fade');
+	    }, 3650);
+	});
 }
 
 // Restores settings options using the preferences
 // stored in chrome.storage.
-function populateSettings() {
+function initSettings() {
   
   // Get preferences or set defaults
   chrome.storage.sync.get({
-    hideUserName: false
+	hideUserName: false,
+	getBrowserNotifications: false
   }, function(items) {
-    document.getElementById('hideUserName').checked = items.hideUserName;
+	document.getElementById('hideUserName').checked = items.hideUserName;
+	document.getElementById('getBrowserNotifications').checked = items.getBrowserNotifications;
 
-    startListeners();
+	startListeners();
   });
 }
 
-document.addEventListener('DOMContentLoaded', populateSettings);
+document.addEventListener('DOMContentLoaded', initSettings);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -30,6 +30,7 @@
     "alarms",
     "cookies",
     "storage",
+    "notifications",
     "webRequest",
     "background",
     "webRequestBlocking",

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -33,6 +33,10 @@
         <input type='checkbox' id='hideUserName' class='option' />
         <label for='hideUserName' class='label'>ווייז נישט מיין ניק ווען איך בין אריינגעסיינט</label>
       </div>
+      <div class='row'>
+        <input type='checkbox' id='getBrowserNotifications' class='option' />
+        <label for='getBrowserNotifications' class='label'>שיק בראוזער נאטיפיקאציעס פון מיין אייוועלט אינבאקס</label>
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
Closes #41 

- Added a new setting for browser notifications, OFF by default for now
- Once turned on, browser will show a notification for every new item in ivelt inbox
- There will be a 10 second wait period between notifications when receiving multiple at once
- Existing notifications at time of installation will not be sent
- Once clicked, a new tab will open to the notification url and the notification will be cleared from the tray