### PR TITLE
migrate to local storage becouse of new limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+extension/_metadata/generated_indexed_rulesets/_ruleset1

--- a/extension/background.notifications.js
+++ b/extension/background.notifications.js
@@ -24,12 +24,12 @@ function parseAndSendNotifications(data){
   var unreadElements = getTagContent(data, 'li', 'row bg3');
   var storeOnly = false;
 
-  chrome.storage.sync.get(['notificationsSent', 'isFreshInstall'], items => {
+  chrome.storage.local.get(['notificationsSent', 'isFreshInstall'], items => {
 
     debugLog('isFreshInstall', items.isFreshInstall);
 
     if(items.isFreshInstall){
-      chrome.storage.sync.remove('isFreshInstall');
+      chrome.storage.local.remove('isFreshInstall');
       storeOnly = true;
     }
 
@@ -85,7 +85,7 @@ function parseAndSendNotifications(data){
 
     // save sent items in storage
     // TODO: prune old ids to avoid storage quota errors
-    chrome.storage.sync.set({
+    chrome.storage.local.set({
       'notificationsSent': notificationsSent
     }, () => {
       // dont send the initial batch

--- a/extension/js/settings.js
+++ b/extension/js/settings.js
@@ -41,9 +41,9 @@ function postSettingChange(items){
 }
 
 function copyLogs(){
-	chrome.storage.sync.get(null, items => {
-		chrome.storage.sync.getBytesInUse(inUse => {
-			let logs = [navigator.userAgent, `Bytes in use: ${inUse}, QUOTA_BYTES: ${chrome.storage.sync.QUOTA_BYTES}, QUOTA_BYTES_PER_ITEM: ${chrome.storage.sync.QUOTA_BYTES_PER_ITEM}`];
+	chrome.storage.local.get(null, items => {
+		chrome.storage.local.getBytesInUse(inUse => {
+			let logs = [navigator.userAgent, `Bytes in use: ${inUse}, QUOTA_BYTES: ${chrome.storage.local.QUOTA_BYTES}, QUOTA_BYTES_PER_ITEM: ${chrome.storage.local.QUOTA_BYTES_PER_ITEM}`];
 			Object.keys(items).forEach(key => {
 				if(key.indexOf('debug-') === 0)
 					logs.push(key + ' -> ' + items[key]);
@@ -54,10 +54,12 @@ function copyLogs(){
 	});
 }
 
+
+
 // Saves settings to chrome.storage
 function commitNewSetting(nameValue){
 
-	chrome.storage.sync.set(nameValue, function() {
+	chrome.storage.local.set(nameValue, function() {
 		// Let user know options were saved.
 		notify();
 	});
@@ -75,7 +77,7 @@ function notify(message){
 function initSettings() {
 
 	// Get all preferences from storage to set fields as needed
-	chrome.storage.sync.get(null, function(items) {
+	chrome.storage.local.get(null, function(items) {
 
 		preferencesOptions.forEach(prefName => {
 			const element = document.getElementById(prefName);

--- a/extension/js/settingsHandler.js
+++ b/extension/js/settingsHandler.js
@@ -1,7 +1,7 @@
 (function(){
 
 	if(chrome.storage){
-		chrome.storage.sync.get(['hideUserName', 'warnOnLosingPost',"sefariaLinker",'backgroundSync', 'backgroundSyncPosts'], function(items){
+		chrome.storage.local.get(['hideUserName', 'warnOnLosingPost',"sefariaLinker",'backgroundSync', 'backgroundSyncPosts'], function(items){
 			if(items.hideUserName){
 				let userName = document.querySelector('.header-avatar .username');
 				if (userName)


### PR DESCRIPTION
chrome has limits on how much and how often data can be stored in sync storage (storage it sync to its cloud service), 
so we need to migrate settings from sync storage to local storage and remove them from sync storage
 

- The quota limitation is approximately 100 KB, 8 KB per item. 
- 1800 Writes per Hour

wee got a lot of errors `MAX_WRITE_OPERATIONS_PER_HOUR` and `QUOTA_BYTES` which broke the background notifications 
see https://developer.chrome.com/docs/extensions/reference/storage/


possible better solution to sync the settings and not the notification, add listener to sync storage changes and update the local
