### PR TITLE
New method for checking for new posts

### DIFF
--- a/extension/js/newResponseNotification.js
+++ b/extension/js/newResponseNotification.js
@@ -1,5 +1,7 @@
 (function () {
-  let currentCount = document
+    if (window.location.pathname !== '/forum/viewtopic.php') return ;
+
+    let currentCount = document
     .querySelector("div.pagination")
     .innerHTML.match(/(\d.) תגובות/)[1];
   let currentPostCount =

--- a/extension/js/newResponseNotification.js
+++ b/extension/js/newResponseNotification.js
@@ -3,7 +3,7 @@
 
     let currentCount = document
     .querySelector("div.pagination")
-    .innerHTML.match(/(\d.) תגובות/)[1];
+    .innerHTML.match(/(\d+) תגובות/)[1];
   let currentPostCount =
     document.getElementsByClassName("post has-profile").length;
   let lastPost =

--- a/extension/js/newResponseNotification.js
+++ b/extension/js/newResponseNotification.js
@@ -1,63 +1,85 @@
-(function(){
-    let currentCount = document.getElementsByClassName("post has-profile").length;
-    let lastPost = document.getElementsByClassName("post has-profile")[currentCount -1]
+(function () {
+  let currentCount = document
+    .querySelector("div.pagination")
+    .innerHTML.match(/(\d.) תגובות/)[1];
+  let currentPostCount =
+    document.getElementsByClassName("post has-profile").length;
+  let lastPost =
+    document.getElementsByClassName("post has-profile")[currentPostCount - 1];
 
-    function isLastPage() {
-        return document.getElementsByClassName("next").length == 0;
+  var topicURL = document.querySelector("h2.topic-title > a").href;
+  var topicURLSearch = topicURL.substr(topicURL.indexOf("?"));
+  var urlParams = new URLSearchParams(topicURLSearch);
+  var topicId = urlParams.get("t");
+  var forumURL = document.getElementsByClassName("left-box arrow-right")[0]
+    .href;
+
+  function isLastPage() {
+    return document.getElementsByClassName("next").length == 0;
+  }
+
+  let title = document.title;
+  // setting was unchecked by the user
+
+  let backgroundSync =
+    document
+      .getElementById("iveltHelperSettings")
+      .getAttribute("data-background-sync") === "true";
+  let backgroundSyncPosts = document
+    .getElementById("iveltHelperSettings")
+    .getAttribute("data-background-sync-posts");
+  if (!backgroundSync || !backgroundSyncPosts) return;
+
+  let interval = parseInt(backgroundSyncPosts);
+  let checkNewResponse = function () {
+    if (isLastPage() && currentCount > 0) {
+      fetch(forumURL)
+        .then(function (response) {
+          return response.text();
+        })
+        .then(function (data) {
+          var parser = new DOMParser();
+          var doc = parser.parseFromString(data, "text/html");
+          let topics = Array.from(
+            Array.from(doc.getElementsByClassName("forumbg"))
+              .pop()
+              .getElementsByClassName("topics")[0]
+              .querySelectorAll("li.row")
+          );
+          let topic = topics.find((t) => {
+            let tHref = t.children[0]?.children[0].children[0].href;
+            if (!tHref) return false;
+            let tHrefSearch = tHref.substr(tHref.indexOf("?"));
+            let tSearch = new URLSearchParams(tHrefSearch);
+            let tId = tSearch.get("t");
+            if (tId == topicId) return true;
+            else return false;
+          });
+          //If we cannot find the topic on the first page of the forum we can safely assume that no new post exists.
+          if (!topic) return setTimeout(checkNewResponse, interval);
+          let newCount =
+            topic.children[0]?.children[1]?.firstChild?.textContent?.trim();
+          if (currentCount < newCount * 1 + 1) {
+            lastPost.insertAdjacentHTML(
+              "afterend",
+              `<h3 style="margin:4px auto;text-align:center;background:#cadceb;padding:7px 5px 5px 5px;border:none;border-radius:7px;user-select:none;">
+                              נייע תגובות זענען צוגעקומען
+                              <a class="button" style="width:150px;margin:5px auto;display:block;" href="/forum/viewtopic.php?t=${topicId}&view=unread#unread">רילאוד</a>
+                          </h3>`
+            );
+            setInterval(function () {
+              document.title =
+                document.title == title ? "\u26B9 " + title : title;
+            }, 500);
+          } else {
+            setTimeout(checkNewResponse, interval);
+          }
+        })
+        .catch(function (error) {
+          interval *= 3;
+          setTimeout(checkNewResponse, interval);
+        });
     }
-
-    let url = window.location.href;
-    let title = document.title;
-    // setting was unchecked by the user
-
-    let backgroundSync = document.getElementById('iveltHelperSettings').getAttribute('data-background-sync') === 'true';
-    let backgroundSyncPosts = document.getElementById('iveltHelperSettings').getAttribute('data-background-sync-posts');
-    if(!backgroundSync || !backgroundSyncPosts)
-        return;
-
-    let interval = parseInt(backgroundSyncPosts);
-    let checkNewResponse = function () {
-        if (isLastPage() && currentCount > 0) {
-            fetch(url)
-            .then(function (response) {
-                return response.text();
-            }).then(function (data) {
-
-                let newCount = (data.match(/class="post has-profile/g) || []).length;
-                let isNewPage = (data.match(/<li class="next">/g) || []).length > 0;
-                if (currentCount < newCount) {
-                    lastPost.insertAdjacentHTML('afterend', 
-                        `<h3 style="margin:4px auto;text-align:center;background:#cadceb;padding:7px 5px 5px 5px;border:none;border-radius:7px;user-select:none;">
-                            נייע תגובות זענען צוגעקומען
-                            <a class="button" style="width:150px;margin:5px auto;display:block;" onclick="window.location.reload();">רילאוד</a>
-                        </h3>`)
-
-                    let markUnreadUrls = (data.match(/\/forum\/app\.php\/markpostunread\/\d+\/\d+/g) || []);
-                    if(markUnreadUrls.length > currentCount)
-                        fetch(markUnreadUrls[currentCount]);
-                    
-                        setInterval(function(){                                   
-                            document.title = (document.title == title ? '\u26B9 ' + title : title);
-                        }, 500);
-                }else if(isNewPage){
-                    lastPost.insertAdjacentHTML('afterend', 
-                        `<h3 style="margin:4px auto;text-align:center;background:#efeed9;padding:5px;border:none;border-radius:7px;user-select:none;">
-                            א נייע בלאט איז צוגעקומען
-                            <a class="button" style="width:150px;margin:6px auto 5px auto;display:block;" ${(data.match(/href=".*" rel="next"/g) || [])[0]}>גיי צום קומענדיגן בלאט</a>
-                        </h3>`)
-                        setInterval(function(){                                   
-                            document.title = (document.title == title ? '\u26B9 ' + title : title);
-                        }, 500);
-                }
-                else{
-                    setTimeout(checkNewResponse, interval);
-                }
-            }).catch(function (error) {
-                    interval *= 3;
-                    setTimeout(checkNewResponse, interval);
-                }
-            )
-        }
-    }
-    setTimeout(checkNewResponse, interval);
+  };
+  setTimeout(checkNewResponse, interval);
 })();


### PR DESCRIPTION
Restructured the way we look for new posts.
Instead of fetching the same page and then each time resetting the unread location, instead we fetch the 'forum' where this topic resides and then check the post count for the specific topic in question.

Included enhancements;

- No longer messing with the "View Count" of the topic
- No longer messing with the "View Count" of images on current page.
- No longer messing with the "Unread" location for the logged in user. Hence, fewer load on the server.
- Changed the link to point to #unread instead of sloppy reloading current page and then having the user confused where to look for the new posts.

Future considerations:

- We only fetch the very first page of the forum to look for the topic assuming that if there is any new post it for sure will show up on the first page. But theoretically it can be on the second page, if we have new posts in more than 50 topics within this forum. We can fetch the second page if the topic is not found on the first page, but currently I don't believe it's needed.
- Check if we're on a topic page. Currently the script runs on any and every page (not only in this new version, this is an old issue).
- For logged in users we can look for the red icon indicating new posts instead of parsing the number of amount of posts. This will accommodate for new posts when some of the old ones got deleted. Currently we only look for the total net amount.