### PR TITLE
fix to load settingsHandler first so its defined  when used by other scripts

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,7 +22,7 @@
         "*://*.yiddishworld.com/*",
         "*://*.198.153.76.147/*"
       ],
-      "js": ["js/contentScript.js","js/refreshNotificationCount.js", "js/settingsHandler.js"]
+      "js": ["js/settingsHandler.js", "js/contentScript.js","js/refreshNotificationCount.js"]
     }
   ],
   "background": {


### PR DESCRIPTION
I was looking of the code, and in the errors, I realized that there was a lot of errors like this:

```
newResponseNotification.js:30 Uncaught TypeError: Cannot read properties of null (reading 'getAttribute')
    at newResponseNotification.js:30:7
    at newResponseNotification.js:88:3
```

after looking into it it seems it comes from loading the content scripts in wrong order, in the [docs](https://developer.chrome.com/docs/extensions/reference/manifest/content-scripts) it says 

> "js" - Array,
Optional. An array of JavaScript file paths, injected in the order they appear in this array, after css files are injected. Each string in the array must be a relative path to a resource in the extension's root directory. Leading slashes ('/') are automatically trimmed

